### PR TITLE
Rework ps2kbd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ lazy_static = { version = '1.2.0', features = ['nightly', 'spin_no_std'] }
 spin = "0.4.10"
 pic8259_simple = "0.1.1"
 linked_list_allocator = "0.6.3"
+pc-keyboard = "0.3.0"
 
 [package.metadata.bootimage]
 default-target = "x86_64-hydroxide.json"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ lazy_static = { version = '1.2.0', features = ['nightly', 'spin_no_std'] }
 spin = "0.4.10"
 pic8259_simple = "0.1.1"
 linked_list_allocator = "0.6.3"
-pc-keyboard = "0.3.0"
+pc-keyboard = { git = "https://github.com/thejpster/pc-keyboard" }
 
 [package.metadata.bootimage]
 default-target = "x86_64-hydroxide.json"

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@ extern crate x86_64;
 extern crate spin;
 extern crate pic8259_simple;
 extern crate linked_list_allocator;
+extern crate pc_keyboard;
 
 //
 //


### PR DESCRIPTION
- Refactor keyboard
- Ignore key events while the keyboard initialization is not yet done
- Properly process and handle key events